### PR TITLE
Version 1.0.7 (Fix FastAPI Content-Type Header ReDoS)

### DIFF
--- a/api/app.py
+++ b/api/app.py
@@ -11,7 +11,7 @@ from api.routers import stats
 from api.models.base import InfoApi
 from api.logger import log
 
-API_VERSION = '1.0.6'
+API_VERSION = '1.0.7'
 API_TITLE = 'Stable Protocol v0 API'
 API_DESCRIPTION = """
 This is a requirement for [stable-protocol-interface](https://github.com/money-on-chain/stable-protocol-interface)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-fastapi==0.100.0
+fastapi==0.109.2
 motor==3.2.0
 pydantic==2.0.3
 pymongo==4.4.1


### PR DESCRIPTION
* New version `v1.0.7`
* [**Quick fix**: FastAPI Content-Type Header ReDoS](https://github.com/money-on-chain/stable-protocol-api/commit/2d744d1daef7d91801bdb920b718669a19ced1f0)